### PR TITLE
s6-networking-man-pages: sync with s6-networking v2.4.1.1 documentation

### DIFF
--- a/s6-tlsc.1
+++ b/s6-tlsc.1
@@ -1,4 +1,4 @@
-.Dd February 16, 2021
+.Dd April 22, 2021
 .Dt S6-TLSC 1
 .Os
 .Sh NAME
@@ -108,10 +108,6 @@ If the peer fails to send data for
 milliseconds during the handshake, close the connection.
 The default is 0, which means infinite timeout (never kill the
 connection).
-This option is ignored by the
-.Ql libtls
-backend, which does not have a way to interrupt the handshake after a
-timeout.
 .It Fl 6 Ar fdr
 Expect an open file descriptor numbered
 .Ar fdr

--- a/s6-tlsd.1
+++ b/s6-tlsd.1
@@ -1,4 +1,4 @@
-.Dd February 16, 2021
+.Dd April 22, 2021
 .Dt S6-TLSD 1
 .Os
 .Sh NAME
@@ -112,10 +112,6 @@ If the peer fails to send data for
 milliseconds during the handshake, close the connection.
 The default is 0, which means infinite timeout (never kill the
 connection).
-This option is ignored by the
-.Ql libtls
-backend, which does not have a way to interrupt the handshake after a
-timeout.
 .El
 .Sh ENVIRONMENT
 .Ss Read


### PR DESCRIPTION
I wasn't entirely sure which formatting strings are required because my mandoc is *terrible* so it's a bit of a best guess.